### PR TITLE
update docker-push, update-deployment ci for use-host-ovs image

### DIFF
--- a/.github/workflows/docker-push-ghcr.yml
+++ b/.github/workflows/docker-push-ghcr.yml
@@ -35,10 +35,18 @@ jobs:
             type=ref,event=pr
             type=sha,prefix=
 
-      - name: "Build and push"
+      - name: "Build and push for Dockerfile"
         uses: docker/build-push-action@v2
         with:
           file: Dockerfile
+          context: .
+          push: true
+          tags: ${{ steps.metaci.outputs.tags }}
+
+      - name: "Build and push for Dockerfile.use-host-ovs"
+        uses: docker/build-push-action@v2
+        with:
+          file: Dockerfile.use-host-ovs
           context: .
           push: true
           tags: ${{ steps.metaci.outputs.tags }}

--- a/.github/workflows/docker-push.yaml
+++ b/.github/workflows/docker-push.yaml
@@ -19,6 +19,7 @@ jobs:
       ORG: networkservicemeshci
       CGO_ENABLED: 0
       NAME: ${{ github.event.repository.name }}
+      IMAGE_SUFFIX: use-host-ovs
     if: ${{ github.repository != 'networkservicemesh/cmd-template' && (github.event.workflow_run.conclusion == 'success' && github.actor == 'nsmbot' || github.ref == 'refs/heads/main') }}
     steps:
       - uses: actions/checkout@v2
@@ -27,12 +28,20 @@ jobs:
           go-version: 1.16
       - name: Build ${NAME}:${GITHUB_SHA::8} image
         run: docker build . -t "${ORG}/${NAME}:${GITHUB_SHA::8}" --target runtime
+      - name: Build ${NAME}-${IMAGE_SUFFIX}:${GITHUB_SHA::8} image
+        run: docker build . -t "${ORG}/${NAME}-${IMAGE_SUFFIX}:${GITHUB_SHA::8}" --target runtime
       - name: Build ${NAME}:latest image
         run: docker build . -t "${ORG}/${NAME}" --target runtime
-      - name: Push ${NAME} images
+      - name: Build ${NAME}-${IMAGE_SUFFIX}:latest image
+        run: docker build . -t "${ORG}/${NAME}-${IMAGE_SUFFIX}" --target runtime
+      - name: Push ${NAME}, ${NAME}-${IMAGE_SUFFIX} images
         run: |
           docker login -u $DOCKER_USER -p $DOCKER_PASSWORD
           docker push "${ORG}/${NAME}:${GITHUB_SHA::8}"
+          docker push "${ORG}/${NAME}-${IMAGE_SUFFIX}:${GITHUB_SHA::8}"
           docker image rm "${ORG}/${NAME}:${GITHUB_SHA::8}"
+          docker image rm "${ORG}/${NAME}-${IMAGE_SUFFIX}:${GITHUB_SHA::8}"
           docker push "${ORG}/${NAME}"
+          docker push "${ORG}/${NAME}-${IMAGE_SUFFIX}"
           docker image rm "${ORG}/${NAME}"
+          docker image rm "${ORG}/${NAME}-${IMAGE_SUFFIX}"

--- a/.github/workflows/update-deployments.yaml
+++ b/.github/workflows/update-deployments.yaml
@@ -13,6 +13,8 @@ jobs:
   update-deployments-k8s:
     name: Update deployments-k8s
     runs-on: ubuntu-latest
+    env:
+      IMAGE_SUFFIX: use-host-ovs
     if: ${{ github.repository != 'networkservicemesh/cmd-template' && (github.event.workflow_run.conclusion == 'success' && github.actor == 'nsmbot' || github.ref == 'refs/heads/main') }}
     steps:
       - name: Checkout ${{ github.repository }}
@@ -42,16 +44,26 @@ jobs:
           git log -1 >> /tmp/commit-message
           echo "Commit Message:"
           cat /tmp/commit-message
-      - name: Find and Replace version
+      - name: Find and Replace ${{ github.event.repository.name }} version
         uses: jacobtomlinson/gha-find-replace@master
         with:
           find: "${{ github.event.repository.name }}:.*\n"
           replace: "${{ github.event.repository.name }}:${{ steps.short-sha.outputs.sha }}\n"
+      - name: Find and Replace ${{ github.event.repository.name }}-${IMAGE_SUFFIX} version
+        uses: jacobtomlinson/gha-find-replace@master
+        with:
+          find: "${{ github.event.repository.name }}-${IMAGE_SUFFIX}:.*\n"
+          replace: "${{ github.event.repository.name }}-${IMAGE_SUFFIX}:${{ steps.short-sha.outputs.sha }}\n"
       - name: Find and Replace ci/${{ github.event.repository.name }} version
         uses: jacobtomlinson/gha-find-replace@master
         with:
           find: "ci/${{ github.event.repository.name }}:.*\n"
           replace: "ci/${{ github.event.repository.name }}:${{ steps.short-sha.outputs.sha }}\n"
+      - name: Find and Replace ci/${{ github.event.repository.name }}-${IMAGE_SUFFIX} version
+        uses: jacobtomlinson/gha-find-replace@master
+        with:
+          find: "ci/${{ github.event.repository.name }}-${IMAGE_SUFFIX}:.*\n"
+          replace: "ci/${{ github.event.repository.name }}-${IMAGE_SUFFIX}:${{ steps.short-sha.outputs.sha }}\n"
       - name: Push update to the deployments-k8s
         working-directory: networkservicemesh/deployments-k8s
         run: |

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/networkservicemesh/cmd-template
+module github.com/networkservicemesh/cmd-forwarder-ovs
 
 go 1.16


### PR DESCRIPTION
This aims to enhance docker push and update deployment ci workflows to include [Dockerfile.use-host-ovs ](https://github.com/networkservicemesh/cmd-forwarder-ovs/blob/main/Dockerfile.use-host-ovs)file in addition to [Dockerfile](https://github.com/networkservicemesh/cmd-forwarder-ovs/blob/main/Dockerfile). 

This PR is outcome of this [review](https://github.com/networkservicemesh/deployments-k8s/pull/2014#discussion_r677412944) comment.

Signed-off-by: Periyasamy Palanisamy <periyasamy.palanisamy@est.tech>