### PR TITLE
Revert "build and push forwarder images with proper naming"

### DIFF
--- a/.github/workflows/docker-push-ghcr.yml
+++ b/.github/workflows/docker-push-ghcr.yml
@@ -30,6 +30,7 @@ jobs:
         id: metaci
         uses: docker/metadata-action@v3
         with:
+          images: ghcr.io/${{ github.repository_owner }}/ci/${{ github.event.repository.name }}
           tags: |
             type=ref,event=pr
             type=sha,prefix=
@@ -37,7 +38,6 @@ jobs:
       - name: "Build and push for Dockerfile"
         uses: docker/build-push-action@v2
         with:
-          images: ghcr.io/${{ github.repository_owner }}/ci/${{ github.event.repository.name }}
           file: Dockerfile
           context: .
           push: true
@@ -46,7 +46,6 @@ jobs:
       - name: "Build and push for Dockerfile.use-host-ovs"
         uses: docker/build-push-action@v2
         with:
-          images: ghcr.io/${{ github.repository_owner }}/ci/${{ github.event.repository.name }}-use-host-ovs
           file: Dockerfile.use-host-ovs
           context: .
           push: true


### PR DESCRIPTION
Reverts networkservicemesh/cmd-forwarder-ovs#21

this commit is still not fixing image naming issue, would raise another commit to fix it.