### PR TITLE
qfix: Add releasing for 'use-host-ovs' docker image for cmd-forwarder-ovs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
     types:
       - completed
     workflows:
-      - 'ci'
+      - "ci"
 jobs:
   docker:
     runs-on: ubuntu-latest
@@ -38,3 +38,11 @@ jobs:
           context: .
           push: true
           tags: "ghcr.io/${{ github.repository_owner }}/${{ github.event.repository.name }}:${{ steps.get-tag-step.outputs.tag }}"
+
+      - name: "Build and push [use-host-ovs]"
+        uses: docker/build-push-action@v2
+        with:
+          file: Dockerfile.use-host-ovs
+          context: .
+          push: true
+          tags: "ghcr.io/${{ github.repository_owner }}/${{ github.event.repository.name }}-use-host-ovs:${{ steps.get-tag-step.outputs.tag }}"


### PR DESCRIPTION
Signed-off-by: denis-tingaikin <denis.tingajkin@xored.com>

## Motivation

Image is used in examples, but it is not handled by release action.

https://github.com/networkservicemesh/cmd-forwarder-ovs/blob/main/Dockerfile.use-host-ovs