### PR TITLE
Refactor forwarder to use updated Options pattern from sdk-ovs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,8 +11,8 @@ require (
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/networkservicemesh/api v1.13.1-0.20240411170402-f357d8c715a2
 	github.com/networkservicemesh/sdk v0.5.1-0.20240418094831-608b1b518564
-	github.com/networkservicemesh/sdk-k8s v0.0.0-20240418095920-671945331706
-	github.com/networkservicemesh/sdk-ovs v0.0.0-20240418100955-9074299d90cb
+	github.com/networkservicemesh/sdk-k8s v0.0.0-20240411170828-cb1ee2e11b80
+	github.com/networkservicemesh/sdk-ovs v0.0.0-20240418152653-d21bcac77d10
 	github.com/networkservicemesh/sdk-sriov v0.0.0-20240418100345-53b4eee751d5
 	github.com/ovn-org/ovn-kubernetes/go-controller v0.0.0-20210826171620-f06c53111a31
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -404,12 +404,12 @@ github.com/networkservicemesh/api v1.13.1-0.20240411170402-f357d8c715a2 h1:R3qJR
 github.com/networkservicemesh/api v1.13.1-0.20240411170402-f357d8c715a2/go.mod h1:B8FmS3XZ7NZY7ZEtdcNg2NHYppDHlr4kl4eecdZN9eI=
 github.com/networkservicemesh/sdk v0.5.1-0.20240418094831-608b1b518564 h1:QEAVhzA0X7YXUvfzx72F/wanN68FqTHM0lN4Msfvwh0=
 github.com/networkservicemesh/sdk v0.5.1-0.20240418094831-608b1b518564/go.mod h1:ERwrGiimSHeUGwgwhgYLl7B/vkYgmIwxZmrQJzJ6hcQ=
-github.com/networkservicemesh/sdk-k8s v0.0.0-20240418095920-671945331706 h1:2E+tZ2QKs/1NJCsn7POtDy5sb3ds4zLAyowfty5KPsQ=
-github.com/networkservicemesh/sdk-k8s v0.0.0-20240418095920-671945331706/go.mod h1:pyMim9f/Y1GSShtz5eI5vLUItYnurbqH/kYd3oMmhxk=
+github.com/networkservicemesh/sdk-k8s v0.0.0-20240411170828-cb1ee2e11b80 h1:EL3HNWhKg+NUTaqsIhiG1Tgf+nv+rl35C4lWDUNvHDc=
+github.com/networkservicemesh/sdk-k8s v0.0.0-20240411170828-cb1ee2e11b80/go.mod h1:WhBobGFD9KmSg88HmwvuoZTh4rL2jd8Sb+96BLlKjgk=
 github.com/networkservicemesh/sdk-kernel v0.0.0-20240418095606-2a4c66902432 h1:cCTF9FNDcsJ6qacwnAFcL+QbmFHMtp3u4R49ebRvTT4=
 github.com/networkservicemesh/sdk-kernel v0.0.0-20240418095606-2a4c66902432/go.mod h1:0I6XLdyHngMeIfl+qmT4UMF78lPpxOPAgOG3y1tjM98=
-github.com/networkservicemesh/sdk-ovs v0.0.0-20240418100955-9074299d90cb h1:qr9nIiel/ybp1c8FBqfqtw47DxYFufHb9Z5bsegyd+I=
-github.com/networkservicemesh/sdk-ovs v0.0.0-20240418100955-9074299d90cb/go.mod h1:1MbOF7vcvPCVfx6El7XpZjgJIZuf8PZuES8dX4008rw=
+github.com/networkservicemesh/sdk-ovs v0.0.0-20240418152653-d21bcac77d10 h1:aIBJcQpoCOO7uaEYM1ATvCxqem29DSnkcRiOqmeP5KI=
+github.com/networkservicemesh/sdk-ovs v0.0.0-20240418152653-d21bcac77d10/go.mod h1:WYghXt3MSjILrkGNQ6r02dpo0QABmq13M+6T5nerzL8=
 github.com/networkservicemesh/sdk-sriov v0.0.0-20240418100345-53b4eee751d5 h1:4wbJPcfFvElP4fCnlElEMcKlXckUYWqvZHuAB8nkNWc=
 github.com/networkservicemesh/sdk-sriov v0.0.0-20240418100345-53b4eee751d5/go.mod h1:FjCG2SNQD0BdTnSg9PcVZmwtOGPh8O1EbTKukNpDUnk=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your changes in the Title above -->
Refactoring forwarder-ovs to use the updated Options patterns from sdk-ovs, just as it has been implemented in the forwarder-vpp.

Depends on: https://github.com/networkservicemesh/sdk-ovs/pull/320
## Issue link
<!--- Please link to the issue here. -->
https://github.com/networkservicemesh/sdk-ovs/issues/319

## How Has This Been Tested?
<!--- Provide information on how these changes are testing -->
- [ ] Added unit testing to cover
- [X] Tested manually
- [ ] Tested by integration testing
- [ ] Have not tested

<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce -->
- [ ] Bug fix
- [ ] New functionality
- [ ] Documentation
- [X] Refactoring
- [ ] CI
